### PR TITLE
Use cl-lib function instead of cl.el for byte-compile warning

### DIFF
--- a/mode-icons.el
+++ b/mode-icons.el
@@ -765,7 +765,7 @@ STRING is the string to modify, or if absent, the value from `mode-line-eol-desc
                         (lambda(x)
                           (and (listp x)
                                (equal (car x) :eval)
-                               (eq (caadr x) 'mode-line-eol-desc)))
+                               (eq (cl-caadr x) 'mode-line-eol-desc)))
                         mode-line-mule-info)))
         (when place
           (setq mode-icons--backup-construct (car place))


### PR DESCRIPTION
This change fixes a following byte-compile warning.

```
In end of data:                                                                   
mode-icons.el:829:1:Warning: the function `caadr' is not known to be defined.
```