### PR TITLE
Fix wrong color in xpm images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   missing from the system
 - mode-icons now allows for a default icon.  This can be turned on
   with the new option `mode-icons-use-default-icon`
+- Fix coloring algorithm for xpm images.
 
 ## [0.4.0]
 

--- a/mode-icons.el
+++ b/mode-icons.el
@@ -315,7 +315,7 @@ If ICON-PATH is a string, return that."
       (and (stringp icon-path) icon-path)))
 
 (defun mode-icons-get-icon-display-xpm-replace (icon-path rep-alist &optional name)
-  "Get xpm image from ICON-PATH and reaplce REP-ALIST in file.
+  "Get xpm image from ICON-PATH and replace REP-ALIST in file.
 When NAME is non-nil, also replace the internal xpm image name."
   (let ((case-fold-search t)
         (img (mode-icons-get-xpm-string icon-path))
@@ -389,7 +389,7 @@ In order, will try to get the foreground color from:
   "Change xpm at ICON-PATH to match FACE.
 The white is changed to the background color.
 The black is changed to the foreground color.
-Grayscale colors are aslo changed by `mode-icons-interpolate-from-scale'."
+Grayscale colors are also changed by `mode-icons-interpolate-from-scale'."
   (let* ((background (mode-icons-background-color face))
          (foreground (mode-icons-foreground-color face))
          (lst (mode-icons-interpolate-from-scale foreground background))

--- a/mode-icons.el
+++ b/mode-icons.el
@@ -318,9 +318,15 @@ If ICON-PATH is a string, return that."
   "Get xpm image from ICON-PATH and reaplce REP-ALIST in file.
 When NAME is non-nil, also replace the internal xpm image name."
   (let ((case-fold-search t)
-        (img (mode-icons-get-xpm-string icon-path)))
+        (img (mode-icons-get-xpm-string icon-path))
+        (i 0))
     (dolist (c rep-alist)
-      (setq img (replace-regexp-in-string (regexp-quote (car c)) (cdr c) img t t)))
+      (setq img (replace-regexp-in-string (regexp-quote (car c)) (format "COLOR<%d>" i) img t t)
+            i (1+ i)))
+    (let ((i 0))
+      (dolist (c rep-alist)
+        (setq img (replace-regexp-in-string (format "COLOR<%d>" i) (cdr c) img t t)
+              i (1+ i))))
     (when name
       (setq img (replace-regexp-in-string "^[ ]*static[ ]+char[ ]+[*][ ]+.*?\\[" (concat "static char * " name "[") img t t)))
     img))


### PR DESCRIPTION
Hi contributors,
the idea about coloring xpm images using string replacement is cool, but I've found a really subtle bug in it.
When some specific color combination is chosen for fore/background, the image is painted in wrong colors.

![screenshot 2017-01-10 21 23 21](https://cloud.githubusercontent.com/assets/4177010/21807380/c250ec6e-d781-11e6-99f4-2238380f87ac.png)
![screenshot 2017-01-10 21 23 57](https://cloud.githubusercontent.com/assets/4177010/21807392/d250b9f0-d781-11e6-9108-f3ab7f9f5fbd.png)

This problem is caused by the string replacement algorithm; some of the colors can be the target of replacement more than once, which leads to wrong painting.
Tested with HEAD version of mode-icons, Emacs 24.5.1 (`emacs -q -l test.el`), OS X Yosemite.

Thanks!