### PR TITLE
Support EnhRuby mode

### DIFF
--- a/mode-icons.el
+++ b/mode-icons.el
@@ -155,6 +155,7 @@ This was stole/modified from `c-save-buffer-state'"
     ("\\`Python\\'" "python" xpm)
     ("\\` Emmet\\'" "emmet" xpm)
     ("\\`Ruby\\'" "ruby" xpm)
+    ("\\`EnhRuby\\'" "ruby" xpm)
     ("\\`ESS\\[S\\]\\'" "R" xpm)
     ("\\`ESS\\[SAS\\]\\'" "sas" xpm)
     ("\\`ESS\\[BUGS\\]\\'" #xf188 FontAwesome)


### PR DESCRIPTION
This adds support for the enh-ruby-mode (Enhanced Ruby Mode). It is just
a replacement for the regular ruby mode and thus uses the same icon.